### PR TITLE
add setVolume support for the audio engine itself alongside an example

### DIFF
--- a/examples/config.nims
+++ b/examples/config.nims
@@ -1,0 +1,1 @@
+switch("path", "$projectDir/../src")

--- a/examples/volume_demo.nim
+++ b/examples/volume_demo.nim
@@ -1,0 +1,19 @@
+import math, std/strformat, std/rdstdin, miniaudio
+
+var engine = AudioEngine.new() 
+
+var
+  sound = loadSoundFromFile(engine, "test.wav")
+
+sound.looping = true
+sound.start()
+
+var volume: float32
+
+for i in 1 .. 10:
+  volume = i/10 
+  engine.setVolume(volume)
+
+  echo fmt"Current Engine Volume: {round(volume*100)}%"
+
+  discard readLineFromStdin("Press Enter to continue...")

--- a/miniaudio.nimble
+++ b/miniaudio.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.1"
+version       = "0.1.2"
 author        = "Jason"
 description   = "A new awesome nimble package"
 license       = "MIT"

--- a/src/miniaudio.nim
+++ b/src/miniaudio.nim
@@ -95,6 +95,8 @@ proc setListenerDir*(engine: AudioEngine, listener: Listener, pos: Vec3) =
   mixin `x`, `y`, `z`
   engine.maEngineListenerSetDirection(uint32 listener, pos.x, pos.y, pos.z)
 
+proc setVolume*(engine: AudioEngine, volume: float32) =
+  wrapError engine.maEngineSetVolume(volume)
 
 converter toMaSoundPtr*(s: Sound): ptr maSound = cast[ptr maSound](s)
 
@@ -141,23 +143,23 @@ proc duplicate*(engine: AudioEngine, sound: Sound): Sound =
   new result
   wrapError maSoundInitCopy(engine, sound, 0, nil, result)
 
-template set(name: untyped, t: typedesc) =
+template setSound(name: untyped, t: typedesc) =
   proc name*(sound: Sound): t =
      sound.`maSoundGet name`()
 
   proc `name =`*(sound: Sound, val: t) =
     sound.`maSoundSet name`(val)
 
-set(volume, float32)
-set(pitch, float32)
-set(pan, float32)
-set(rolloff, float32)
-set(minGain, float32)
-set(maxGain, float32)
-set(minDistance, float32)
-set(maxDistance, float32)
-set(dopplerFactor, float32)
-set(panMode, maPanMode)
+setSound(volume, float32)
+setSound(pitch, float32)
+setSound(pan, float32)
+setSound(rolloff, float32)
+setSound(minGain, float32)
+setSound(maxGain, float32)
+setSound(minDistance, float32)
+setSound(maxDistance, float32)
+setSound(dopplerFactor, float32)
+setSound(panMode, maPanMode)
 
 
 template setVec3s(name: untyped) =


### PR DESCRIPTION
Hi, I was the one that talked to you the other day on Nim's official irc/discord channel. I realized that although there's a volume support for the `sound` itself, there's no support for the audio engine. So, I added `setVolume` for audio engine. I added a simple example I made inside `examples/volume_demo.nim`

I also changed the name you used for the template `set` to `setSound` instead to make it clear that those are templates for sound-related functions.